### PR TITLE
fix: added severity check to go

### DIFF
--- a/deployable/go/main.go
+++ b/deployable/go/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
@@ -207,7 +208,33 @@ func simplelog(args map[string]string) {
 		logtext = val
 	}
 
-	logger := client.Logger(logname).StandardLogger(logging.Info)
+	logseverity := logging.Info
+	if val, ok := args["severity"]; ok {
+		switch strings.ToUpper(val) {
+		case "DEFAULT":
+			logseverity = logging.Default
+		case "DEBUG":
+			logseverity = logging.Debug
+		case "INFO":
+			logseverity = logging.Info
+		case "NOTICE":
+			logseverity = logging.Notice
+		case "WARNING":
+			logseverity = logging.Warning
+		case "ERROR":
+			logseverity = logging.Error
+		case "CRITICAL":
+			logseverity = logging.Critical
+		case "ALERT":
+			logseverity = logging.Alert
+		case "EMERGENCY":
+			logseverity = logging.Emergency
+		default:
+			break
+		}
+	}
+
+	logger := client.Logger(logname).StandardLogger(logseverity)
 	logger.Println(logtext)
 }
 

--- a/envctl/env_scripts/go/cloudrun.sh
+++ b/envctl/env_scripts/go/cloudrun.sh
@@ -18,7 +18,7 @@ set -o pipefail # any step in pipe caused failure
 set -u # undefined variables cause exit
 
 # Note: there is a max character count constraint
-SERVICE_NAME="log-go-run-$(echo $ENVCTL_ID | head -c 8)x"
+SERVICE_NAME="log-go-run-$(echo $ENVCTL_ID | head -c 8)"
 SA_NAME=$SERVICE_NAME-invoker
 
 add_service_accounts() {


### PR DESCRIPTION
This PR adds severity to the go environment tests (in line with other languages). This will cause the broken testgrid checks to pass

I also removed an unneeded character from the cloudrun deployment script