### PR TITLE
chore(deps): Update python and dependency

### DIFF
--- a/deployable/python/requirements.txt
+++ b/deployable/python/requirements.txt
@@ -3,3 +3,4 @@ google-cloud-pubsub>=2.8.0
 click==7.1.2
 pytz==2021.1
 pandas>=1.1.5
+itsdangerous==2.0.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -69,7 +69,7 @@ def _determine_local_import_names(start_dir: str) -> List[str]:
 # We also need to specify the rules which are ignored by default:
 # ['E226', 'W504', 'E126', 'E123', 'W503', 'E24', 'E704', 'E121']
 
-DEFAULT_PYTHON_VERSION = "3.7"
+DEFAULT_PYTHON_VERSION = "3.9"
 BLACK_PATHS = ["./deployable/python"]
 BLACK_VERSION = "black==19.10b0"
 


### PR DESCRIPTION
Upgrade to python 3.9 for test environment to enable proper building
of dependencies.

Pin itsdangerous to 2.0.1 to fix a build error with flask 1.1.2 as a
result of the deprecation of the JSON API of that package.