### PR TITLE
chore: add custom sync repo settings

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,0 +1,21 @@
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/sync-repo-settings
+# Rules for main branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `main`
+- pattern: main
+  requiresCodeOwnerReviews: true
+  requiresStrictStatusChecks: true
+  requiredStatusCheckContexts:
+    - 'cla/google'
+permissionRules:
+  - team: actools-python
+    permission: admin
+  - team: actools
+    permission: admin
+  - team: yoshi-python
+    permission: push
+  - team: python-samples-owners
+    permission: push
+  - team: python-samples-reviewers
+    permission: push


### PR DESCRIPTION
There are status checks in this repo that are marked as required but are never triggered. This PR adds a sync-repo-settings.yaml file which will remove the unnecessary checks and override the defaults defined [here](https://github.com/googleapis/repo-automation-bots/blob/main/packages/sync-repo-settings/src/required-checks.json#L39).