### PR TITLE
java: added java functions test file

### DIFF
--- a/tests/java/test_functions.py
+++ b/tests/java/test_functions.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/java/test_functions.py
+++ b/tests/java/test_functions.py
@@ -1,0 +1,30 @@
+# Copyright 2016 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import unittest
+import inspect
+
+import google.cloud.logging
+
+from ..common.common import Common
+
+
+class TestCloudFunctions(Common, unittest.TestCase):
+
+    environment = "functions"
+    language = "java"
+
+    monitored_resource_name = "cloud_function"
+    monitored_resource_labels = ["region", "function_name"]


### PR DESCRIPTION
We recently [implemented java functions support](https://github.com/googleapis/env-tests-logging/pull/88), but didn't add the test file necessary for tests to run against it. This PR adds that file