### PR TITLE
fix: uuid generation with different python versions

### DIFF
--- a/envctl/envctl
+++ b/envctl/envctl
@@ -25,7 +25,7 @@ fi
 set -e
 
 # create and destroy temporary dir
-UUID=$(python  -c 'import uuid; print(uuid.uuid1())')
+UUID="${UUID:-$(python$ENV_TEST_PY_VERSION  -c 'import uuid; print(uuid.uuid1())')}"
 TMP_DIR=$REPO_ROOT/tmp-$UUID
 mkdir $TMP_DIR
 function finish {


### PR DESCRIPTION
envctl was previously using `python` to generate a uuid value meant to create a unique temporary directory. This was causing issues on the go tests, which don't have a `python` executable (using python3 instead)

This fix guards against this issue by:
1. not creating a uuid if it was already generated as an environment variable
2. adding `ENV_TEST_PY_VERSION` to the python version if set. This was already used as a solution for different Python versions, so if it is already set, it can fix this problen