### PR TITLE
python: added tests for json_field data

### DIFF
--- a/deployable/python/snippets.py
+++ b/deployable/python/snippets.py
@@ -122,6 +122,27 @@ def pylogging(log_text="pylogging", severity="WARNING", **kwargs):
     else:
         logging.critical(log_text, extra=kwargs)
 
+def pylogging_json_extras(log_text="pylogging with json extras", severity="WARNING", **kwargs):
+    # allowed severity: debug, info, warning, error, critical
+
+    # build json message
+    metadata = {}
+    prefix = "jsonfield_"
+    for k, v in kwargs.items():
+        if k.startswith(prefix):
+            metadata[k.replace(prefix, "")] = int(v) if v.isnumeric() else v
+
+    severity = severity.upper()
+    if severity == "DEBUG":
+        logging.debug(log_text, extra={"json_fields": metadata})
+    elif severity == "INFO":
+        logging.info(log_text, extra={"json_fields": metadata})
+    elif severity == "WARNING":
+        logging.warning(log_text, extra={"json_fields": metadata})
+    elif severity == "ERROR":
+        logging.error(log_text, extra={"json_fields": metadata})
+    else:
+        logging.critical(log_text, extra={"json_fields": metadata})
 
 def pylogging_multiline(log_text="pylogging", second_line="line 2", **kwargs):
     logging.error(f"{log_text}\n{second_line}")
@@ -145,7 +166,6 @@ def pylogging_with_formatter(
 
 def pylogging_with_arg(log_text="my_arg", **kwargs):
     logging.error("Arg: %s", log_text)
-
 
 def pylogging_flask(
     log_text="pylogging_flask",

--- a/deployable/python/snippets.py
+++ b/deployable/python/snippets.py
@@ -122,7 +122,10 @@ def pylogging(log_text="pylogging", severity="WARNING", **kwargs):
     else:
         logging.critical(log_text, extra=kwargs)
 
-def pylogging_json_extras(log_text="pylogging with json extras", severity="WARNING", **kwargs):
+
+def pylogging_json_extras(
+    log_text="pylogging with json extras", severity="WARNING", **kwargs
+):
     # allowed severity: debug, info, warning, error, critical
 
     # build json message
@@ -143,6 +146,7 @@ def pylogging_json_extras(log_text="pylogging with json extras", severity="WARNI
         logging.error(log_text, extra={"json_fields": metadata})
     else:
         logging.critical(log_text, extra={"json_fields": metadata})
+
 
 def pylogging_multiline(log_text="pylogging", second_line="line 2", **kwargs):
     logging.error(f"{log_text}\n{second_line}")
@@ -166,6 +170,7 @@ def pylogging_with_formatter(
 
 def pylogging_with_arg(log_text="my_arg", **kwargs):
     logging.error("Arg: %s", log_text)
+
 
 def pylogging_flask(
     log_text="pylogging_flask",

--- a/envctl/env_scripts/python/compute.sh
+++ b/envctl/env_scripts/python/compute.sh
@@ -28,13 +28,13 @@ destroy() {
   export GCR_PATH=gcr.io/$PROJECT_ID/logging:$SERVICE_NAME
   gcloud container images delete $GCR_PATH -q --force-delete-tags 2> /dev/null
   # delete service
-  gcloud compute instances delete $SERVICE_NAME -q
+  gcloud compute instances delete $SERVICE_NAME --zone us-west1-c -q
   set -e
 }
 
 verify() {
   set +e
-  gcloud compute instances describe $SERVICE_NAME > /dev/null 2> /dev/null
+  gcloud compute instances describe $SERVICE_NAME --zone us-west1-c > /dev/null 2> /dev/null
   if [[ $? == 0 ]]; then
      echo "TRUE"
      exit 0
@@ -50,6 +50,7 @@ deploy() {
   gcloud compute instances create-with-container \
     $SERVICE_NAME \
     --container-image $GCR_PATH \
+    --zone us-west1-c \
     --container-env PUBSUB_TOPIC="$SERVICE_NAME",ENABLE_SUBSCRIBER="true"
   # wait for the pub/sub subscriber to start
   NUM_SUBSCRIBERS=0

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,7 +70,7 @@ def _determine_local_import_names(start_dir: str) -> List[str]:
 # We also need to specify the rules which are ignored by default:
 # ['E226', 'W504', 'E126', 'E123', 'W503', 'E24', 'E704', 'E121']
 
-DEFAULT_PYTHON_VERSION = os.getenv("ENV_TEST_PY_VERSION","3.9")
+DEFAULT_PYTHON_VERSION = os.getenv("ENV_TEST_PY_VERSION", "3.9")
 BLACK_PATHS = ["./deployable/python"]
 BLACK_VERSION = "black==19.10b0"
 
@@ -133,7 +133,7 @@ def blacken(session: nox.sessions.Session) -> None:
         "kubernetes",
         "cloudrun",
         "functions",
-        "functions_v2"
+        "functions_v2",
     ],
 )
 @nox.parametrize("language", ["python", "go", "nodejs", "java"])

--- a/tests/common/python.py
+++ b/tests/common/python.py
@@ -362,11 +362,15 @@ class CommonPython:
         log_text = f"{inspect.currentframe().f_code.co_name} {uuid.uuid1()}"
         log_dict = {
             "jsonfield_component": "arbitrary-property",
-            "jsonfield_severity":"error",
-            "jsonfield_message": "duplicate message"
+            "jsonfield_severity": "error",
+            "jsonfield_message": "duplicate message",
         }
         log_list = self.trigger_and_retrieve(
-            log_text, "pylogging_json_extras", append_uuid=False, severity="info", **log_dict
+            log_text,
+            "pylogging_json_extras",
+            append_uuid=False,
+            severity="info",
+            **log_dict,
         )
 
         found_log = log_list[-1]
@@ -374,4 +378,6 @@ class CommonPython:
         self.assertIsNotNone(found_log, "expected log text not found")
         self.assertTrue(isinstance(found_log.payload, dict), "expected jsonPayload")
         self.assertEqual(found_log.payload["message"], log_text)
-        self.assertEqual(found_log.severity.lower(), "info", "severity should be set by logger")
+        self.assertEqual(
+            found_log.severity.lower(), "info", "severity should be set by logger"
+        )

--- a/tests/common/python.py
+++ b/tests/common/python.py
@@ -356,3 +356,22 @@ class CommonPython:
         df = df.append({"log_text": log_text}, ignore_index=True)
 
         self.assertEqual(str(df), message)
+
+    def test_pylogging_conflicting_severity(self):
+        # test different severity values in json_fields and logger
+        log_text = f"{inspect.currentframe().f_code.co_name} {uuid.uuid1()}"
+        log_dict = {
+            "jsonfield_component": "arbitrary-property",
+            "jsonfield_severity":"error",
+            "jsonfield_message": "duplicate message"
+        }
+        log_list = self.trigger_and_retrieve(
+            log_text, "pylogging_json_extras", append_uuid=False, severity="info", **log_dict
+        )
+
+        found_log = log_list[-1]
+
+        self.assertIsNotNone(found_log, "expected log text not found")
+        self.assertTrue(isinstance(found_log.payload, dict), "expected jsonPayload")
+        self.assertEqual(found_log.payload["message"], log_text)
+        self.assertEqual(found_log.severity.lower(), "info", "severity should be set by logger")


### PR DESCRIPTION
Related to https://github.com/googleapis/python-logging/issues/543

test the python logging integration using reserved field names in the `json_fields` data