### PR TITLE
go: update golang versions in tests

### DIFF
--- a/deployable/go/Dockerfile
+++ b/deployable/go/Dockerfile
@@ -16,7 +16,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.15-buster as builder
+FROM golang:1.19-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app
@@ -26,6 +26,7 @@ COPY . ./
 
 # Build the binary
 RUN go mod download
+RUN go mod tidy
 RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.

--- a/deployable/go/go.mod
+++ b/deployable/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/env-tests-logging/deployable/go/main
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go/compute v1.7.0
@@ -11,3 +11,5 @@ require (
 )
 
 replace cloud.google.com/go/logging => ./logging
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab

--- a/envctl/env_scripts/go/appengine_standard.sh
+++ b/envctl/env_scripts/go/appengine_standard.sh
@@ -60,7 +60,7 @@ deploy() {
 
   # manual_scaling allows 1 instance to continuously run regardless of the load level.
   cat <<EOF > $TMP_DIR/app.yaml
-    runtime: go119
+    runtime: go115
     service: $SERVICE_NAME
     manual_scaling:
       instances: 1

--- a/envctl/env_scripts/go/appengine_standard.sh
+++ b/envctl/env_scripts/go/appengine_standard.sh
@@ -60,7 +60,7 @@ deploy() {
 
   # manual_scaling allows 1 instance to continuously run regardless of the load level.
   cat <<EOF > $TMP_DIR/app.yaml
-    runtime: go115
+    runtime: go119
     service: $SERVICE_NAME
     manual_scaling:
       instances: 1

--- a/envctl/env_scripts/go/functions.sh
+++ b/envctl/env_scripts/go/functions.sh
@@ -47,9 +47,8 @@ deploy() {
   set +e
   gcloud pubsub topics create $SERVICE_NAME 2>/dev/null
   set -e
-  # Note: functions only supports go111, go113 and go116 at the moment
-  local RUNTIME="go116"
-
+  # Note: functions supports go111, go113 go116, go118, and go119
+  local RUNTIME="go119"
 
   # Copy over local copy of library to use as dependency
   _deployable_dir=$REPO_ROOT/deployable/$LANGUAGE


### PR DESCRIPTION
Update from golang 1.5 to 1.9, to be compatible with latest library dependencies

This should fix the current errors on our dashboard