### PR TITLE
feat: add go http_request tests

### DIFF
--- a/deployable/go/main.go
+++ b/deployable/go/main.go
@@ -227,6 +227,18 @@ func (s Snippets) Simplelog(args map[string]string) {
 		Payload:  logtext,
 		Severity: logseverity,
 	}
+	// attach http request object if passed in
+	if input_url, ok := args["http_request_url"]; ok {
+		log.Printf("Got url :%q\n", input_url)
+		if parsed_url, err := url.Parse(input_url); err == nil {
+			entry.HTTPRequest = &logging.HTTPRequest{
+				Request: &http.Request{
+					URL:    parsed_url,
+					Method: "POST",
+				},
+			}
+		}
+	}
 	client.Logger(logname).Log(entry)
 }
 
@@ -324,6 +336,17 @@ func (s Snippets) Synclog(args map[string]string) {
 		Payload:  logtext,
 		Severity: logseverity,
 	}
+	// attach http request object if passed in
+	if input_url, ok := args["http_request_url"]; ok {
+		if parsed_url, err := url.Parse(input_url); err == nil {
+			entry.HTTPRequest = &logging.HTTPRequest{
+				Request: &http.Request{
+					URL:    parsed_url,
+					Method: "POST",
+				},
+			}
+		}
+	}
 	lg.LogSync(ctx, entry)
 }
 
@@ -353,6 +376,17 @@ func (s Snippets) Stdoutlog(args map[string]string) {
 	entry := logging.Entry{
 		Payload:  logtext,
 		Severity: logseverity,
+	}
+	// attach http request object if passed in
+	if input_url, ok := args["http_request_url"]; ok {
+		if parsed_url, err := url.Parse(input_url); err == nil {
+			entry.HTTPRequest = &logging.HTTPRequest{
+				Request: &http.Request{
+					URL:    parsed_url,
+					Method: "POST",
+				},
+			}
+		}
 	}
 	lg.LogSync(ctx, entry)
 }

--- a/deployable/go/main.go
+++ b/deployable/go/main.go
@@ -344,6 +344,7 @@ func (s Snippets) Synclog(args map[string]string) {
 					Method: "POST",
 				},
 			}
+			entry.HTTPRequest.Latency = 100000
 		}
 	}
 	lg.LogSync(ctx, entry)
@@ -385,6 +386,7 @@ func (s Snippets) Stdoutlog(args map[string]string) {
 					Method: "POST",
 				},
 			}
+			entry.HTTPRequest.Latency = 100000
 		}
 	}
 	lg.LogSync(ctx, entry)

--- a/deployable/go/main.go
+++ b/deployable/go/main.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -118,9 +119,22 @@ func pullMsgsSync(sub *pubsub.Subscription) error {
 // Initializations for all GCP services
 var ctx context.Context
 
+// global project id
+var projectID string
+
 // init executes for all environments, regardless if its a program or package
 func init() {
 	ctx = context.Background()
+	// populate projectId
+	var found bool
+	projectID, found = os.LookupEnv("PROJECT_ID")
+	if !found {
+		var err error
+		projectID, err = metadata.ProjectID()
+		if err != nil {
+			log.Fatalf("metadata.ProjectID: %v", err)
+		}
+	}
 }
 
 // main runs for all environments except GCF
@@ -129,14 +143,6 @@ func main() {
 	// Enable app subscriber for all environments except GCR
 	if os.Getenv("ENABLE_SUBSCRIBER") == "true" {
 		// first look for project id in env var, then check the metadata
-		projectID, found := os.LookupEnv("PROJECT_ID")
-		if !found {
-			var err error
-			projectID, err = metadata.ProjectID()
-			if err != nil {
-				log.Fatalf("metadata.ProjectID: %v", err)
-			}
-		}
 		topicID := os.Getenv("PUBSUB_TOPIC")
 		if topicID == "" {
 			topicID = "logging-test"
@@ -199,10 +205,6 @@ type Snippets struct{}
 // [Optional] envctl go <env> trigger simplelog log_name=foo,log_text=bar
 func (s Snippets) Simplelog(args map[string]string) {
 	ctx := context.Background()
-	projectID, err := metadata.ProjectID()
-	if err != nil {
-		log.Fatalf("metadata.ProjectID: %v", err)
-	}
 	client, err := logging.NewClient(ctx, projectID)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
@@ -231,10 +233,6 @@ func (s Snippets) Simplelog(args map[string]string) {
 // [Optional] envctl go <env> trigger jsonlog log_name=foo,log_text=bar
 func (s Snippets) Jsonlog(args map[string]string) {
 	ctx := context.Background()
-	projectID, err := metadata.ProjectID()
-	if err != nil {
-		log.Fatalf("metadata.ProjectID: %v", err)
-	}
 	client, err := logging.NewClient(ctx, projectID)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
@@ -276,10 +274,6 @@ func (s Snippets) Jsonlog(args map[string]string) {
 // [Optional] envctl go <env> trigger standardlogger log_name=foo,log_text=bar
 func (s Snippets) Standardlogger(args map[string]string) {
 	ctx := context.Background()
-	projectID, err := metadata.ProjectID()
-	if err != nil {
-		log.Fatalf("metadata.ProjectID: %v", err)
-	}
 	client, err := logging.NewClient(ctx, projectID)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
@@ -307,10 +301,6 @@ func (s Snippets) Standardlogger(args map[string]string) {
 // [Optional] envctl go <env> trigger synclog log_name=foo,log_text=bar
 func (s Snippets) Synclog(args map[string]string) {
 	ctx := context.Background()
-	projectID, err := metadata.ProjectID()
-	if err != nil {
-		log.Fatalf("metadata.ProjectID: %v", err)
-	}
 	client, err := logging.NewClient(ctx, projectID)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
@@ -341,10 +331,6 @@ func (s Snippets) Synclog(args map[string]string) {
 // [Optional] envctl go <env> trigger stdoutlog log_name=foo,log_text=bar
 func (s Snippets) Stdoutlog(args map[string]string) {
 	ctx := context.Background()
-	projectID, err := metadata.ProjectID()
-	if err != nil {
-		log.Fatalf("metadata.ProjectID: %v", err)
-	}
 	client, err := logging.NewClient(ctx, projectID)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)

--- a/deployable/go/main.go
+++ b/deployable/go/main.go
@@ -229,7 +229,6 @@ func (s Snippets) Simplelog(args map[string]string) {
 	}
 	// attach http request object if passed in
 	if input_url, ok := args["http_request_url"]; ok {
-		log.Printf("Got url :%q\n", input_url)
 		if parsed_url, err := url.Parse(input_url); err == nil {
 			entry.HTTPRequest = &logging.HTTPRequest{
 				Request: &http.Request{

--- a/envctl/env_scripts/go/compute.sh
+++ b/envctl/env_scripts/go/compute.sh
@@ -54,7 +54,7 @@ build_go_container(){
 
   # copy over local copy of library
   pushd $SUPERREPO_ROOT/logging
-    tar -cvf $_deployable_dir/lib.tar --exclude internal/env-tests-logging --exclude .nox --exclude docs --exclude __pycache__ .
+    tar -cvf $_deployable_dir/lib.tar --exclude env-tests-logging --exclude internal/env-tests-logging --exclude .nox --exclude docs --exclude __pycache__ .
   popd
   mkdir -p $_deployable_dir/logging
   tar -xvf $_deployable_dir/lib.tar --directory $_deployable_dir/logging

--- a/tests/go/go.py
+++ b/tests/go/go.py
@@ -92,3 +92,19 @@ class CommonGolang:
             found_severity = log_list[-1].severity
 
             self.assertEqual(found_severity.lower(), severity.lower())
+
+    def test_http_request(self):
+        log_text = f"{inspect.currentframe().f_code.co_name}"
+        test_url = "www.google.com"
+        log_list = self.trigger_and_retrieve(log_text, "simplelog", http_request_url=test_url)
+
+        found_log = log_list[-1]
+
+        self.assertIsNotNone(found_log, "expected log text not found")
+
+        found_request = log_list[-1].http_request
+        self.assertIsNotNone(found_request)
+        self.assertIsNotNone(found_request["requestUrl"])
+        self.assertEqual(found_request["requestUrl"], test_url)
+
+

--- a/tests/go/stdout.py
+++ b/tests/go/stdout.py
@@ -67,3 +67,18 @@ class CommonStdout:
 
             self.assertEqual(found_severity.lower(), severity.lower())
 
+    def test_http_request_stdout(self):
+        log_text = f"{inspect.currentframe().f_code.co_name}"
+        test_url = "www.google.com"
+        log_list = self.trigger_and_retrieve(log_text, "stdoutlog", http_request_url=test_url)
+
+        found_log = log_list[-1]
+
+        self.assertIsNotNone(found_log, "expected log text not found")
+
+        found_request = log_list[-1].http_request
+        self.assertIsNotNone(found_request)
+        self.assertIsNotNone(found_request["requestUrl"])
+        self.assertEqual(found_request["requestUrl"], test_url)
+
+


### PR DESCRIPTION
- adds tests that http requests are sent in the proper format (related bug: https://github.com/googleapis/google-cloud-go/pull/7083)
- fixes the `go local` test target, to use modified container building function used by other go env tests.
  - previously the test wasn't using the local library version
- environment tests use env var project id when provided, rather than checking with the metadata server