### PR TITLE
chore: pin grpc version to avoid threading issue

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -152,6 +152,7 @@ def tests(session, language, platform):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install(
+        "grpcio==1.51.1", # pinned to avoid https://github.com/grpc/grpc/issues/31885 TODO: revert
         "mock",
         "pytest",
         "google-cloud-testutils",


### PR DESCRIPTION
The environment tests are currently failing due to a [grpc dependency issue.](https://github.com/grpc/grpc/issues/31885) This PR pins grpc to version 1.51.1, which does not exhibit the issue